### PR TITLE
Return HexBytes from slice of HexBytes

### DIFF
--- a/hexbytes/__init__.py
+++ b/hexbytes/__init__.py
@@ -1,1 +1,3 @@
-from .main import HexBytes  # noqa: F401
+from .main import (  # noqa: F401
+    HexBytes,
+)

--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -2,6 +2,7 @@ from typing import (
     Type,
     Union,
     cast,
+    overload,
 )
 
 from eth_utils import (
@@ -28,6 +29,21 @@ class HexBytes(bytes):
         Just like :meth:`bytes.hex`, but prepends "0x"
         '''
         return '0x' + super().hex()
+
+    @overload
+    def __getitem__(self, key: int) -> int:
+        ...
+
+    @overload  # noqa: F811
+    def __getitem__(self, key: slice) -> 'HexBytes':
+        ...
+
+    def __getitem__(self, key: Union[int, slice]) -> Union[int, bytes, 'HexBytes']:  # noqa: F811
+        result = super().__getitem__(key)
+        if hasattr(result, 'hex'):
+            return type(self)(result)
+        else:
+            return result
 
     def __repr__(self) -> str:
         return 'HexBytes(%r)' % self.hex()

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,4 @@ python_paths= .
 xfail_strict=true
 
 [pytest-watch]
-runner= py.test --failed-first --maxfail=1 --no-success-flaky-report
+runner= py.test --failed-first --maxfail=1

--- a/tests/test_hexbytes.py
+++ b/tests/test_hexbytes.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eth_utils import (
     decode_hex,
     remove_0x_prefix,
@@ -42,3 +44,29 @@ def test_hex_inputs(hex_input):
 def test_pretty_output():
     hb = HexBytes(b'\x0F\x1a')
     assert repr(hb) == "HexBytes('0x0f1a')"
+
+
+@given(st.binary(), st.integers())
+def test_hexbytes_index(primitive, index):
+    hexbytes = HexBytes(primitive)
+    if index >= len(primitive) or index < -1 * len(primitive):
+        with pytest.raises(IndexError):
+            hexbytes[index]
+    else:
+        assert hexbytes[index] == primitive[index]
+
+
+@given(st.binary(), st.integers(), st.integers())
+def test_slice(primitive, start, stop):
+    hexbytes = HexBytes(primitive)
+    expected = HexBytes(primitive[start:stop])
+    assert hexbytes[start:stop] == expected
+
+
+@given(st.binary(), st.integers(), st.integers(), st.integers())
+def test_slice_stepped(primitive, start, stop, step):
+    hexbytes = HexBytes(primitive)
+    if step == 0:
+        step = None
+    expected = HexBytes(primitive[start:stop:step])
+    assert hexbytes[start:stop:step] == expected


### PR DESCRIPTION
## What was wrong?

Fixes #8 


## How was it fixed?

If the super-value returns a class that has a `hex()` representation (which `bytes` does, and `int` does not), then return it as a `HexBytes()`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/ckfkzJ8hJyc/maxresdefault.jpg)
