### PR TITLE
Update supported Python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,24 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
 
 workflows:
   version: 2
@@ -70,3 +88,6 @@ workflows:
       - lint
       - py36-core
       - py37-core
+      - py38-core
+      - py39-core
+      - py310-core

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest==5.4.1",
+        "pytest==7.0.1",
         "pytest-xdist",
         "tox==3.14.6",
-        "hypothesis>=3.44.24,<4",
+        "hypothesis>=3.44.24,<=6.31.6",
         'eth-utils>=1.0.1,<2',
     ],
     'lint': [
@@ -75,5 +75,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37,py3}-core
+    py{36,37,38,39,310,py3}-core
     lint
     docs
 
@@ -28,6 +28,9 @@ basepython =
     docs: python
     py36: python3.6
     py37: python3.7
+    py38: python3.8
+    py39: python3.9
+    py310: python3.10
     pypy3: pypy3
 extras=
     test


### PR DESCRIPTION
Simply testing minimum/maximum versions should be good (CircleCI does not yet provide an image for Python 3.11 though).