### PR TITLE
Support memoryview

### DIFF
--- a/hexbytes/_utils.py
+++ b/hexbytes/_utils.py
@@ -4,7 +4,7 @@ from typing import (
 )
 
 
-def to_bytes(val: Union[bool, bytearray, bytes, int, str]) -> bytes:
+def to_bytes(val: Union[bool, bytearray, bytes, int, str, memoryview]) -> bytes:
     """
     Equivalent to: `eth_utils.hexstr_if_str(eth_utils.to_bytes, val)` .
 
@@ -26,12 +26,14 @@ def to_bytes(val: Union[bool, bytearray, bytes, int, str]) -> bytes:
             raise ValueError(f"Cannot convert negative integer {val} to bytes")
         else:
             return to_bytes(hex(val))
+    elif isinstance(val, memoryview):
+        return bytes(val)
     else:
         raise TypeError(f"Cannot convert {val!r} of type {type(val)} to bytes")
 
 
 def hexstr_to_bytes(hexstr: str) -> bytes:
-    if hexstr.startswith("0x") or hexstr.startswith("0X"):
+    if hexstr.startswith(("0x", "0X")):
         non_prefixed_hex = hexstr[2:]
     else:
         non_prefixed_hex = hexstr

--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -19,7 +19,7 @@ class HexBytes(bytes):
         2. Returns hex with prefix '0x' from :meth:`HexBytes.hex`
         3. The representation at console is in hex
     """
-    def __new__(cls: Type[bytes], val: Union[bool, bytearray, bytes, int, str]) -> "HexBytes":
+    def __new__(cls: Type[bytes], val: Union[bool, bytearray, bytes, int, str, memoryview]) -> "HexBytes":
         bytesval = to_bytes(val)
         return cast(HexBytes, super().__new__(cls, bytesval))  # type: ignore  # https://github.com/python/typeshed/issues/2630  # noqa: E501
 

--- a/tests/core/test_hexbytes.py
+++ b/tests/core/test_hexbytes.py
@@ -37,6 +37,13 @@ def test_bytearray_inputs(primitive):
     assert_equal(wrapped, primitive)
 
 
+@given(st.binary())
+def test_memoryview_inputs(primitive):
+    memoryview_input = memoryview(primitive)
+    wrapped = HexBytes(memoryview_input)
+    assert_equal(wrapped, primitive)
+
+
 @pytest.mark.parametrize(
     'boolval, expected_repr',
     (


### PR DESCRIPTION
- `bytes` can cast `memoryview`, so `HexBytes` should be able too
