### PR TITLE
Add black

### DIFF
--- a/hexbytes/_utils.py
+++ b/hexbytes/_utils.py
@@ -45,8 +45,10 @@ def hexstr_to_bytes(hexstr: str) -> bytes:
         padded_hex = non_prefixed_hex
 
     try:
-        ascii_hex = padded_hex.encode('ascii')
+        ascii_hex = padded_hex.encode("ascii")
     except UnicodeDecodeError:
-        raise ValueError(f"hex string {padded_hex} may only contain [0-9a-fA-F] characters")
+        raise ValueError(
+            f"hex string {padded_hex} may only contain [0-9a-fA-F] characters"
+        )
     else:
         return binascii.unhexlify(ascii_hex)

--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -28,7 +28,8 @@ class HexBytes(bytes):
     HexBytes is a *very* thin wrapper around the python built-in :class:`bytes` class.
 
     It has these three changes:
-        1. Accepts more initializing values, like hex strings, non-negative integers, and booleans
+        1. Accepts more initializing values, like hex strings, non-negative integers,
+           and booleans
         2. Returns hex with prefix '0x' from :meth:`HexBytes.hex`
         3. The representation at console is in hex
     """

--- a/newsfragments/26.misc.rst
+++ b/newsfragments/26.misc.rst
@@ -1,0 +1,1 @@
+Add black linting

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ extras_require = {
         "isort>=4.2.15,<5",
         "mypy==0.971",
         "pydocstyle>=5.0.0,<6",
+        "black>=22,<23",
     ],
     "doc": [
         "Sphinx>=1.6.5,<2",

--- a/tests/core/test_hexbytes.py
+++ b/tests/core/test_hexbytes.py
@@ -13,7 +13,7 @@ from hexbytes import (
     HexBytes,
 )
 
-hexstr_strategy = st.from_regex(r'\A(0[xX])?[0-9a-fA-F]*\Z')
+hexstr_strategy = st.from_regex(r"\A(0[xX])?[0-9a-fA-F]*\Z")
 
 
 def assert_equal(hexbytes, bytes_expected):
@@ -45,7 +45,7 @@ def test_memoryview_inputs(primitive):
 
 
 @pytest.mark.parametrize(
-    'boolval, expected_repr',
+    "boolval, expected_repr",
     (
         (True, "HexBytes('0x01')"),
         (False, "HexBytes('0x00')"),
@@ -63,7 +63,7 @@ def test_invalid_integer_inputs(integer):
         HexBytes(integer)
 
     message = str(exc_info.value)
-    assert 'negative' in message
+    assert "negative" in message
     assert str(integer) in message
 
 
@@ -80,13 +80,13 @@ def test_hex_inputs(hex_input):
     if len(hex_input) % 2 == 0:
         even_hex_input = hex_input
     else:
-        even_hex_input = '0' + remove_0x_prefix(hex_input)
+        even_hex_input = "0" + remove_0x_prefix(hex_input)
     expected = decode_hex(even_hex_input)
     assert_equal(wrapped, expected)
 
 
 def test_pretty_output():
-    hb = HexBytes(b'\x0F\x1a')
+    hb = HexBytes(b"\x0F\x1a")
     assert repr(hb) == "HexBytes('0x0f1a')"
 
 

--- a/tests/core/test_import.py
+++ b/tests/core/test_import.py
@@ -1,4 +1,2 @@
-
-
 def test_import():
     import hexbytes  # noqa: F401

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ multi_line_output=3
 use_parentheses=True
 
 [flake8]
-max-line-length= 100
+max-line-length=88
 exclude= venv*,.tox,docs,build
 ignore=
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ commands=
     flake8 {toxinidir}/hexbytes {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/hexbytes {toxinidir}/tests
     pydocstyle --explain {toxinidir}/hexbytes {toxinidir}/tests
+    black {toxinidir}/hexbytes {toxinidir}/tests --check
 
 [testenv:py{36,37,38,39,310}-lint]
 deps={[common-lint]deps}


### PR DESCRIPTION
## What was wrong?

hexbytes needed black to be added. This was branched off of the `update-mypy` branch and should be merged after. Only the last three commits are relevant here.


## How was it fixed?

Added black, and decreased the line length to 88.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/hexbytes/blob/master/newsfragments/README.md)

[//]: # (See: https://hexbytes.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F24%2F2020%2F06%2F08%2FGettyImages-10141026-1bunnies.-vikkihart-2000.jpg&q=60)
