### PR TITLE
Update sphinx, drop python 3.6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,18 +43,6 @@ jobs:
       - image: cimg/python:3.10
         environment:
           TOXENV: docs
-  py36-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.6
-        environment:
-          TOXENV: py36-lint
-  py36-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.6
-        environment:
-          TOXENV: py36-core
   py37-lint:
     <<: *common
     docker:
@@ -109,12 +97,10 @@ workflows:
   test:
     jobs:
       - docs
-      - py36-lint
       - py37-lint
       - py38-lint
       - py39-lint
       - py310-lint
-      - py36-core
       - py37-core
       - py38-core
       - py39-core

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -281,7 +281,7 @@ texinfo_documents = [
 # -- Intersphinx configuration ------------------------------------------------
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.6", None),
+    "python": ("https://docs.python.org/3.10", None),
 }
 
 # -- Doctest configuration ----------------------------------------

--- a/newsfragments/27.breaking.rst
+++ b/newsfragments/27.breaking.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.6, update Sphinx doc dependency requirement

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,9 @@ extras_require = {
         "black>=22,<23",
     ],
     "doc": [
-        "Sphinx>=1.6.5,<2",
+        "Sphinx>=4.0.0,<5",
         "sphinx_rtd_theme>=0.1.9,<1",
         "towncrier>=21,<22",
-        "jinja2>=3.0.0,<3.1.0",  # jinja2<3.0 or >=3.1.0 cause doc build failures.
     ],
     "dev": [
         "bumpversion>=0.5.3,<1",
@@ -59,7 +58,7 @@ setup(
     url="https://github.com/ethereum/hexbytes",
     include_package_data=True,
     install_requires=[],
-    python_requires=">=3.6, <4",
+    python_requires=">=3.7, <4",
     extras_require=extras_require,
     py_modules=["hexbytes"],
     license="MIT",
@@ -75,7 +74,6 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,38,39,310,py3}-core
-    py{36,37,38,39,310}-lint
+    py{37,38,39,310,py3}-core
+    py{37,38,39,310}-lint
     docs
 
 [isort]
@@ -26,7 +26,6 @@ commands=
     docs: make check-docs
 basepython =
     docs: python
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9
@@ -46,7 +45,7 @@ commands=
     pydocstyle --explain {toxinidir}/hexbytes {toxinidir}/tests
     black {toxinidir}/hexbytes {toxinidir}/tests --check
 
-[testenv:py{36,37,38,39,310}-lint]
+[testenv:py{37,38,39,310}-lint]
 deps={[common-lint]deps}
 commands={[common-lint]commands}
 


### PR DESCRIPTION
## What was wrong?

Python 3.6 support ended in Dec. 2021. 

## How was it fixed?

Removed testing against Python 3.6. Also updated Sphinx and was able to remove the Jinja2 dependency pin. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/hexbytes/blob/master/newsfragments/README.md)

[//]: # (See: https://hexbytes.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/e0/7b/59/e07b59ed6c4c43441be586d48a56ad62.jpg)
