### PR TITLE
Bump eth-utils

### DIFF
--- a/newsfragments/28.misc.rst
+++ b/newsfragments/28.misc.rst
@@ -1,0 +1,1 @@
+Remove DeprecationWarning by allowing a higher version of eth-utils

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
         "pytest-xdist",
         "tox>=3.25.1,<4",
         "hypothesis>=3.44.24,<=6.31.6",
-        "eth-utils>=1.0.1,<2",
+        "eth-utils>=1.0.1,<3",
     ],
     "lint": [
         "flake8==3.7.9",


### PR DESCRIPTION
## What was wrong?
I noticed a deprecation warning at the end of the test run that was taken care of in eth-utils v2.0.0.

## How was it fixed?

Opened up the dependency requirement. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/hexbytes/blob/master/newsfragments/README.md)

[//]: # (See: https://hexbytes.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.saymedia-content.com/.image/t_share/MTczOTg4MTA1OTExNTQzNjc1/land-hermit-crab-species.jpg)
