### PR TITLE
add build.os config to rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,13 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
 python:
   install:
     - method: pip

--- a/newsfragments/34.internal.rst
+++ b/newsfragments/34.internal.rst
@@ -1,0 +1,1 @@
+Add ``build.os`` config for readthedocs


### PR DESCRIPTION
### What was wrong?

ReadTheDocs will soon start requiring `build.os` config

### How was it fixed?

Added to readthedocs.yml

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/hexbytes/assets/5199899/e41dcc39-d47f-4cfb-ab17-ffcf6eefe8e6)