### PR TITLE
move prepend of 0x to HexBytes.__repr__

### DIFF
--- a/docs/hexbytes.rst
+++ b/docs/hexbytes.rst
@@ -8,11 +8,11 @@ Install with:
 
 .. code-block:: bash
 
-    pip install hexbytes
+    python -m pip install hexbytes
 
 Example :class:`~hexbytes.main.HexBytes` usage:
 
-::
+.. doctest::
 
     >>> from hexbytes import HexBytes
 
@@ -22,7 +22,15 @@ Example :class:`~hexbytes.main.HexBytes` usage:
 
     # HexBytes accepts the hex string representation as well, ignoring case and 0x prefixes
     >>> hb = HexBytes('03087766BF68E78671D1EA436AE087DA74A12761DAC020011A9EDDC4900BF13B')
+    >>> hb
     HexBytes('0x03087766bf68e78671d1ea436ae087da74a12761dac020011a9eddc4900bf13b')
+
+    # HexBytes does not override the .hex() or __str__ methods of the parent `bytes` type
+    >>> hb = HexBytes('03087766BF68E78671D1EA436AE087DA74A12761DAC020011A9EDDC4900BF13B')
+    >>> hb.hex()
+    '03087766bf68e78671d1ea436ae087da74a12761dac020011a9eddc4900bf13b'
+    >>> print(hb)
+    b"\x03\x08wf\xbfh\xe7\x86q\xd1\xeaCj\xe0\x87\xdat\xa1'a\xda\xc0 \x01\x1a\x9e\xdd\xc4\x90\x0b\xf1;"
 
     # get the first byte:
     >>> hb[0]

--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -31,26 +31,15 @@ class HexBytes(bytes):
     """
     HexBytes is a *very* thin wrapper around the python built-in :class:`bytes` class.
 
-    It has these three changes:
+    It has these changes:
         1. Accepts more initializing values, like hex strings, non-negative integers,
            and booleans
-        2. Returns hex with prefix '0x' from :meth:`HexBytes.hex`
-        3. The representation at console is in hex
+        2. The representation at console (__repr__) is 0x-prefixed
     """
 
     def __new__(cls: Type[bytes], val: BytesLike) -> "HexBytes":
         bytesval = to_bytes(val)
         return cast(HexBytes, super().__new__(cls, bytesval))  # type: ignore  # https://github.com/python/typeshed/issues/2630  # noqa: E501
-
-    def hex(
-        self, sep: Union[str, bytes] = None, bytes_per_sep: "SupportsIndex" = 1
-    ) -> str:
-        """
-        Output hex-encoded bytes, with an "0x" prefix.
-
-        Everything following the "0x" is output exactly like :meth:`bytes.hex`.
-        """
-        return "0x" + super().hex()
 
     @overload
     def __getitem__(self, key: "SupportsIndex") -> int:  # noqa: F811
@@ -70,4 +59,4 @@ class HexBytes(bytes):
             return result
 
     def __repr__(self) -> str:
-        return f"HexBytes({self.hex()!r})"
+        return f"HexBytes({'0x' + self.hex()!r})"

--- a/newsfragments/38.breaking.rst
+++ b/newsfragments/38.breaking.rst
@@ -1,0 +1,1 @@
+Move HexBytes prepend of ``0x`` from ``hex`` method to ``__repr__`` to not break ``hex`` of parent ``bytes`` class

--- a/tests/core/test_hexbytes.py
+++ b/tests/core/test_hexbytes.py
@@ -90,6 +90,11 @@ def test_pretty_output():
     assert repr(hb) == "HexBytes('0x0f1a')"
 
 
+def test_does_not_break_bytes_hex():
+    hb = HexBytes(b"\x0F\x1a")
+    assert hb.hex() == "0f1a"
+
+
 @given(st.binary(), st.integers())
 def test_hexbytes_index(primitive, index):
     hexbytes = HexBytes(primitive)


### PR DESCRIPTION
### What was wrong?

`HexBytes.hex` altered `bytes.hex` by  prepending `0x`, which caused some users problems.

Related to Issue #
Closes #14 
Closes #29 

### How was it fixed?
 - Moved the `0x` prefix to `HexBytes.__repr__`

Note: this is breaking, but `hexbytes` is still <v1 - next release should be to next minor version (0.4.0).
### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/master/newsfragments/README.md)
- [x] Add testing

#### Cute Animal Picture

![image](https://github.com/ethereum/hexbytes/assets/5199899/8f4ca40c-8242-4af8-8d78-eb6a3e8b7bef)
