### PR TITLE
add to_0x_hex method to easily create 0x-prefixed strings

### DIFF
--- a/docs/hexbytes.rst
+++ b/docs/hexbytes.rst
@@ -32,6 +32,11 @@ Example :class:`~hexbytes.main.HexBytes` usage:
     >>> print(hb)
     b"\x03\x08wf\xbfh\xe7\x86q\xd1\xeaCj\xe0\x87\xdat\xa1'a\xda\xc0 \x01\x1a\x9e\xdd\xc4\x90\x0b\xf1;"
 
+    # Use the `to_0x_hex` method to get a 0x-prefixed hex string
+    >>> hb.to_0x_hex()
+    '0x03087766bf68e78671d1ea436ae087da74a12761dac020011a9eddc4900bf13b'
+
+
     # get the first byte:
     >>> hb[0]
     3

--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -26,7 +26,8 @@ class HexBytes(bytes):
         1. Accepts more initializing values, like hex strings, non-negative integers,
            and booleans
         2. The representation at console (__repr__) is 0x-prefixed
-    """
+        3. The to_0x_hex method is added to convert the bytes to a 0x-prefixed hex string
+    """  # noqa: E501
 
     def __new__(cls: Type[bytes], val: BytesLike) -> "HexBytes":
         bytesval = to_bytes(val)
@@ -51,3 +52,9 @@ class HexBytes(bytes):
 
     def __repr__(self) -> str:
         return f"HexBytes({'0x' + self.hex()!r})"
+
+    def to_0x_hex(self) -> str:
+        """
+        Convert the bytes to a 0x-prefixed hex string
+        """
+        return "0x" + self.hex()

--- a/newsfragments/43.feature.rst
+++ b/newsfragments/43.feature.rst
@@ -1,0 +1,1 @@
+Add ``to_0x_hex()`` method to provide a quick, explicit way to get an 0x-prefixed string

--- a/tests/core/test_hexbytes.py
+++ b/tests/core/test_hexbytes.py
@@ -95,6 +95,11 @@ def test_does_not_break_bytes_hex():
     assert hb.hex() == "0f1a"
 
 
+def test_to_0x_hex():
+    hb = HexBytes(b"\x0F\x1a")
+    assert hb.to_0x_hex() == "0x0f1a"
+
+
 @given(st.binary(), st.integers())
 def test_hexbytes_index(primitive, index):
     hexbytes = HexBytes(primitive)


### PR DESCRIPTION
### What was wrong?

In PR #38, I changed the function of the `.hex()` method to drop the `0x`-prefix to match the parent `bytes` class. But it turns out some other libs depend on there being a quick method to render an 0x-prefixed string.

### How was it fixed?

Added the `to_0x_hex()` method to provide the same functionality `.hex()` used to have, but more explicitly.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/hexbytes/assets/5199899/de4d54fa-8cb9-44e8-aa17-3e5bc83385e1)
