### PR TITLE
fix docs ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,14 +86,32 @@ windows-wheel-steps:
       key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 docs: &docs
-  docker:
-    - image: common
+  working_directory: ~/repo
   steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: install latexpdf dependencies
         command: |
           sudo apt-get update
           sudo apt-get install latexmk tex-gyre texlive-fonts-extra
+    - run:
+        name: run tox
+        command: python -m tox run -r
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+  resource_class: xlarge
 
 jobs:
   docs:

--- a/newsfragments/46.misc.rst
+++ b/newsfragments/46.misc.rst
@@ -1,0 +1,1 @@
+Fix docs CI - it was only installing deps, not actually running tox


### PR DESCRIPTION
### What was wrong?

Fix docs CI - it was only installing deps, not actually running tox

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/hexbytes/assets/5199899/d5577189-9c9f-473f-9f48-0e6aac5e4e08)
