### PR TITLE
run mypy local, remove extra git check during release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,11 +43,14 @@ repos:
     -   id: mdformat
         additional_dependencies:
         -   mdformat-gfm
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+-   repo: local
     hooks:
-    -   id: mypy
-        exclude: tests/
+    -   id: mypy-local
+        name: run mypy with all dev dependencies present
+        entry: python -m mypy -p hexbytes
+        language: system
+        always_run: true
+        pass_filenames: false
 -   repo: https://github.com/PrincetonUniversity/blocklint
     rev: v0.2.5
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,6 @@ ifndef bump
 endif
 
 check-git:
-	# require that you be on a branch that's linked to upstream/main
-	@if ! git status -s -b | head -1 | grep -q "\.\.upstream/main"; then \
-		echo "Error: You must be on a branch that's linked to upstream/main"; \
-		exit 1; \
-	fi
 	# require that upstream is configured for ethereum/hexbytes
 	@if ! git remote -v | grep "upstream[[:space:]]git@github.com:ethereum/hexbytes.git (push)\|upstream[[:space:]]https://github.com/ethereum/hexbytes (push)"; then \
 		echo "Error: You must have a remote named 'upstream' that points to 'hexbytes'"; \

--- a/newsfragments/47.internal.rst
+++ b/newsfragments/47.internal.rst
@@ -1,0 +1,1 @@
+Run ``mypy`` with local deps installed instead of ``pre-commit`` ``mirrors-mypy`` hook.

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
         "build>=0.9.0",
         "bump_my_version>=0.19.0",
         "ipython",
+        "mypy==1.10.0",
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ allowlist_externals=make,pre-commit
 
 [testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
+extras=dev
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
### What was wrong?

`mypy` should be run with local deps installed.
We only need one check that we're connected to an `upstream` during release.


### How was it fixed?

run mypy with all local deps installed, remove extra git upstream check during release process

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/hexbytes/assets/5199899/2a19c47f-79aa-41f1-bdca-355ff6844bd9)
