### PR TITLE
fix make notes version parsing for bump-my-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ package-test: clean
 
 notes: check-bump
 	# Let UPCOMING_VERSION be the version that is used for the current bump
-	$(eval UPCOMING_VERSION=$(shell bump-my-version show --increment $(bump) new_version))
+	$(eval UPCOMING_VERSION=$(shell bump-my-version bump --dry-run $(bump) -v | awk -F"'" '/New version will be / {print $$2}'))
 	# Now generate the release notes to have them included in the release commit
 	towncrier build --yes --version $(UPCOMING_VERSION)
 	# Before we bump the version, make sure that the towncrier-generated docs will build


### PR DESCRIPTION
### What was wrong?

Changing from `bumpversion` to `bump-my-version` broke `make notes` when releasing a new beta.

### How was it fixed?

Updated parsing to handle both commands like `make notes bump=minor` and `make notes bump="--new-version 8.0.0-beta.1`

No docs updates. Doesn't need a newsfragment.

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/81187249-3328-4e0f-8224-fe80b2039ae7)
