### PR TITLE
bump towncrier dep from 21<22 to 24<25

### DIFF
--- a/newsfragments/49.internal.rst
+++ b/newsfragments/49.internal.rst
@@ -1,0 +1,1 @@
+Bump ``towncrier`` dep from ``>=21,<22`` to ``>=24,<25``

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
     "docs": [
         "sphinx>=5.3.0",
         "sphinx_rtd_theme>=1.0.0",
-        "towncrier>=21,<22",
+        "towncrier>=24,<25",
     ],
     "test": [
         "eth_utils>=2.0.0",


### PR DESCRIPTION
### What was wrong?

`towncrier` has started to raise `pkg_resources`-related errors:

```
towncrier build --draft --version preview
/venv/lib/python3.12/site-packages/towncrier/_settings.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
/venv/lib/python3.12/site-packages/pkg_resources/__init__.py:3154: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
  declare_namespace(pkg)
```


### How was it fixed?

Bump dep from `>=21,<22` to `>=24,<25`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/e18e6e14-f02c-4a75-9369-5eaca5c9b9a5)

