### PR TITLE
Upgrade template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,10 +101,12 @@ docs: &docs
         name: install latexpdf dependencies
         command: |
           sudo apt-get update
-          sudo apt-get install latexmk tex-gyre texlive-fonts-extra
+          sudo apt-get install latexmk tex-gyre texlive-fonts-extra texlive-xetex xindy
     - run:
         name: run tox
         command: python -m tox run -r
+    - store_artifacts:
+          path: /home/circleci/repo/docs/_build
     - save_cache:
         paths:
           - .tox
@@ -117,7 +119,7 @@ jobs:
   docs:
     <<: *docs
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
         environment:
           TOXENV: docs
 
@@ -151,6 +153,12 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-core
+  py313-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-core
 
   py38-lint:
     <<: *common
@@ -182,6 +190,12 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-lint
+  py313-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-lint
 
   py38-wheel:
     <<: *common
@@ -213,6 +227,12 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-wheel
+  py313-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-wheel
 
   py311-windows-wheel:
     <<: *windows-wheel-setup
@@ -240,25 +260,54 @@ jobs:
       - <<: *run-tox-step
       - <<: *save-cache-step
 
+  py313-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.13'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
+
+define: &all_jobs
+  - docs
+  - py38-core
+  - py39-core
+  - py310-core
+  - py311-core
+  - py312-core
+  - py313-core
+  - py38-lint
+  - py39-lint
+  - py310-lint
+  - py311-lint
+  - py312-lint
+  - py313-lint
+  - py38-wheel
+  - py39-wheel
+  - py310-wheel
+  - py311-wheel
+  - py312-wheel
+  - py313-wheel
+  - py311-windows-wheel
+  - py312-windows-wheel
+  - py313-windows-wheel
+
 workflows:
   version: 2
   test:
-    jobs:
-      - docs
-      - py38-core
-      - py39-core
-      - py310-core
-      - py311-core
-      - py312-core
-      - py38-lint
-      - py39-lint
-      - py310-lint
-      - py311-lint
-      - py312-lint
-      - py38-wheel
-      - py39-wheel
-      - py310-wheel
-      - py311-wheel
-      - py312-wheel
-      - py311-windows-wheel
-      - py312-windows-wheel
+    jobs: *all_jobs
+  nightly:
+    triggers:
+      - schedule:
+          # Weekdays 12:00p UTC
+          cron: "0 12 * * 1,2,3,4,5"
+          filters:
+            branches:
+              only:
+                - main
+    jobs: *all_jobs

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ logs
 # vs-code
 .vscode
 
+# jupyter notebook files
+*.ipynb
+
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # For a more precise, explicit template, see:
 # https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.10"
 
 sphinx:
   configuration: docs/conf.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2023 The Ethereum Foundation
+Copyright (c) 2019-2025 The Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.md
 
+recursive-include scripts *
 recursive-include tests *
 
 global-include *.pyi

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,19 @@ help:
 	@echo "clean-build - remove build artifacts"
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "clean - run clean-build and clean-pyc"
+	@echo "dist - build package and cat contents of the dist directory"
 	@echo "lint - fix linting issues with pre-commit"
 	@echo "test - run tests quickly with the default Python"
 	@echo "docs - generate docs and open in browser (linux-docs for version on linux)"
-	@echo "notes - consume towncrier newsfragments/ and update release notes in docs/"
-	@echo "release - package and upload a release (does not run notes target)"
+	@echo "autobuild-docs - live update docs when changes are saved"
+	@echo "package-test - build package and install it in a venv for manual testing"
+	@echo "notes - consume towncrier newsfragments and update release notes in docs - requires bump to be set"
+	@echo "release - package and upload a release (does not run notes target) - requires bump to be set"
 
 clean-build:
 	rm -fr build/
 	rm -fr dist/
+	rm -fr *.egg-info
 
 clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +
@@ -24,6 +28,10 @@ clean-pyc:
 
 clean: clean-build clean-pyc
 
+dist: clean
+	python -m build
+	ls -l dist
+
 lint:
 	@pre-commit run --all-files --show-diff-on-failure || ( \
 		echo "\n\n\n * pre-commit should have fixed the errors above. Running again to make sure everything is good..." \
@@ -31,7 +39,7 @@ lint:
 	)
 
 test:
-	pytest tests
+	python -m pytest tests
 
 # docs commands
 
@@ -40,6 +48,9 @@ docs: check-docs
 
 linux-docs: check-docs
 	xdg-open docs/_build/html/index.html
+
+autobuild-docs:
+	sphinx-autobuild --open-browser docs docs/_build/html
 
 # docs helpers
 
@@ -54,8 +65,6 @@ build-docs:
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest
-
-# docs helpers for CI, which requires extra dependencies
 
 check-docs-ci: build-docs build-docs-ci validate-newsfragments
 

--- a/README.md
+++ b/README.md
@@ -12,30 +12,10 @@ Read the [documentation](https://hexbytes.readthedocs.io/).
 
 View the [change log](https://hexbytes.readthedocs.io/en/latest/release_notes.html).
 
-## Quickstart
+View the [change log](https://%3CRTD_NAME%3E.readthedocs.io/en/latest/release_notes.html).
+
+## Installation
 
 ```sh
 python -m pip install hexbytes
-```
-
-```py
-# convert from bytes to a prettier representation at the console
->>> HexBytes(b"\x03\x08wf\xbfh\xe7\x86q\xd1\xeaCj\xe0\x87\xdat\xa1'a\xda\xc0 \x01\x1a\x9e\xdd\xc4\x90\x0b\xf1;")
-HexBytes('0x03087766bf68e78671d1ea436ae087da74a12761dac020011a9eddc4900bf13b')
-
-# HexBytes accepts the hex string representation as well, ignoring case and 0x prefixes
->>> hb = HexBytes('03087766BF68E78671D1EA436AE087DA74A12761DAC020011A9EDDC4900BF13B')
-HexBytes('0x03087766bf68e78671d1ea436ae087da74a12761dac020011a9eddc4900bf13b')
-
-# get the first byte:
->>> hb[0]
-3
-
-# show how many bytes are in the value
->>> len(hb)
-32
-
-# cast back to the basic `bytes` type
->>> bytes(hb)
-b"\x03\x08wf\xbfh\xe7\x86q\xd1\xeaCj\xe0\x87\xdat\xa1'a\xda\xc0 \x01\x1a\x9e\xdd\xc4\x90\x0b\xf1;"
 ```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Read the [documentation](https://hexbytes.readthedocs.io/).
 
 View the [change log](https://hexbytes.readthedocs.io/en/latest/release_notes.html).
 
-View the [change log](https://%3CRTD_NAME%3E.readthedocs.io/en/latest/release_notes.html).
-
 ## Installation
 
 ```sh

--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -5,7 +5,7 @@ Our Pledge
 ~~~~~~~~~~
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, gender identity and expression, level of experience,
 education, socio-economic status, nationality, personal appearance, race,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# HexBytes documentation build configuration file, created by
+# <PROJECT_NAME> documentation build configuration file, created by
 # sphinx-quickstart on Thu Oct 16 20:43:24 2014.
 #
 # This file is execfile()d with the current directory set to its
@@ -19,7 +17,7 @@
 
 import os
 
-DIR = os.path.dirname("__file__")
+DIR = os.path.dirname(__file__)
 with open(os.path.join(DIR, "../setup.py"), "r") as f:
     for line in f:
         if "version=" in line:
@@ -195,14 +193,16 @@ htmlhelp_basename = "hexbytesdocs"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-# latex_elements = {
-#   # The paper size ('letterpaper' or 'a4paper').
-#   'papersize': 'letterpaper',
-#   # The font size ('10pt', '11pt' or '12pt').
-#   'pointsize': '10pt',
-#   # Additional stuff for the LaTeX preamble.
-#   'preamble': '',
-# }
+latex_engine = "xelatex"
+
+latex_elements = {
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+}
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# <PROJECT_NAME> documentation build configuration file, created by
+# HexBytes documentation build configuration file, created by
 # sphinx-quickstart on Thu Oct 16 20:43:24 2014.
 #
 # This file is execfile()d with the current directory set to its

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -13,7 +13,7 @@ development machine:
 
 .. code:: sh
 
-    git clone git@github.com:your-github-username/<REPO_NAME>.git
+    git clone git@github.com:your-github-username/hexbytes.git
 
 Next, install the development dependencies. We recommend using a virtual environment,
 such as `virtualenv <https://virtualenv.pypa.io/en/stable/>`_.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -13,8 +13,7 @@ development machine:
 
 .. code:: sh
 
-    git clone git@github.com:your-github-username/hexbytes.git
-
+    git clone git@github.com:your-github-username/<REPO_NAME>.git
 
 Next, install the development dependencies. We recommend using a virtual environment,
 such as `virtualenv <https://virtualenv.pypa.io/en/stable/>`_.
@@ -38,7 +37,6 @@ We can run all tests with:
 
     pytest tests
 
-
 Code Style
 ~~~~~~~~~~
 
@@ -49,7 +47,6 @@ manually with:
 .. code:: sh
 
     make lint
-
 
 If you need to make a commit that skips the ``pre-commit`` checks, you can do so with
 ``git commit --no-verify``.
@@ -74,7 +71,7 @@ a discussion, and doesn't necessarily need to be the final, finished submission.
 GitHub's documentation for working on pull requests is
 `available here <https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`_.
 
-Once you've made a pull request take a look at the Circle CI build status in the
+Once you've made a pull request, take a look at the Circle CI build status in the
 GitHub interface and make sure all tests are passing. In general pull requests that
 do not pass the CI build yet won't get reviewed unless explicitly requested.
 
@@ -100,9 +97,7 @@ Before releasing a new version, build and test the package that will be released
 .. code:: sh
 
     git checkout main && git pull
-
     make package-test
-
 
 This will build the package and install it in a temporary virtual environment. Follow
 the instructions to activate the venv and test whatever you think is important.
@@ -112,7 +107,6 @@ You can also preview the release notes:
 .. code:: sh
 
     towncrier --draft
-
 
 Build the release notes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -135,7 +129,6 @@ After confirming that the release package looks okay, release a new version:
 .. code:: sh
 
     make release bump=$$VERSION_PART_TO_BUMP$$
-
 
 This command will:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 HexBytes
---------
+========
 
 HexBytes is a *very* thin wrapper around the python built-in ``bytes`` class.
 
@@ -18,7 +18,7 @@ It adds these features:
 
 
 Installation
-~~~~~~~~~~~~
+------------
 
 .. code-block:: bash
 

--- a/newsfragments/50.feature.rst
+++ b/newsfragments/50.feature.rst
@@ -1,0 +1,1 @@
+Merge template, adding `py313` suppport and removing ``bumpversion`` for ``bump-my-version``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,28 +1,31 @@
 [tool.autoflake]
-remove_all_unused_imports = true
 exclude = "__init__.py"
+remove_all_unused_imports = true
 
 [tool.isort]
 combine_as_imports = true
 extra_standard_library = "pytest"
 force_grid_wrap = 1
 force_sort_within_sections = true
-known_third_party = "hypothesis,pytest"
+force_to_top = "pytest"
+honor_noqa = true
 known_first_party = "hexbytes"
+known_third_party = "hypothesis"
 multi_line_output = 3
 profile = "black"
+use_parentheses = true
 
 [tool.mypy]
 check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
 disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
-disallow_subclassing_any = true
+disallow_untyped_defs = true
 ignore_missing_imports = true
-strict_optional = true
 strict_equality = true
+strict_optional = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unused_configs = true
@@ -63,18 +66,18 @@ add-ignore = "D200,D203,D204,D205,D212,D302,D400,D401,D412,D415"
 
 [tool.pytest.ini_options]
 addopts = "-v --showlocals --durations 10"
-xfail_strict = true
-log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
 log_date_format = "%m-%d %H:%M:%S"
+log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
+xfail_strict = true
 
 [tool.towncrier]
-# Read https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md for instructions
-package = "hexbytes"
-filename = "docs/release_notes.rst"
+# Read https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md for instructions
 directory = "newsfragments"
+filename = "docs/release_notes.rst"
+issue_format = "`#{issue} <https://github.com/ethereum/<REPO_NAME>/issues/{issue}>`__"
+package = "<MODULE_NAME>"
+title_format = "<REPO_NAME> v{version} ({project_date})"
 underlines = ["-", "~", "^"]
-title_format = "hexbytes v{version} ({project_date})"
-issue_format = "`#{issue} <https://github.com/ethereum/hexbytes/issues/{issue}>`__"
 
 [[tool.towncrier.type]]
 directory = "breaking"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,12 +71,12 @@ log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
 xfail_strict = true
 
 [tool.towncrier]
-# Read https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md for instructions
+# Read https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md for instructions
 directory = "newsfragments"
 filename = "docs/release_notes.rst"
-issue_format = "`#{issue} <https://github.com/ethereum/<REPO_NAME>/issues/{issue}>`__"
-package = "<MODULE_NAME>"
-title_format = "<REPO_NAME> v{version} ({project_date})"
+issue_format = "`#{issue} <https://github.com/ethereum/hexbytes/issues/{issue}>`__"
+package = "hexbytes"
+title_format = "hexbytes v{version} ({project_date})"
 underlines = ["-", "~", "^"]
 
 [[tool.towncrier.type]]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ extras_require = {
         "wheel",
     ],
     "docs": [
-        "sphinx>=5.3.0",
+        "sphinx>=6.0.0",
+        "sphinx-autobuild>=2021.3.14",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=24,<25",
     ],
@@ -39,7 +40,7 @@ with open("./README.md") as readme:
 
 setup(
     name="hexbytes",
-    # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
+    # *IMPORTANT*: Don't manually change the version here. See Contributing docs for the release process.
     version="1.2.1",
     description="""hexbytes: Python `bytes` subclass that decodes hex, with a readable console output""",
     long_description=long_description,
@@ -55,7 +56,7 @@ setup(
     license="MIT",
     zip_safe=False,
     keywords="ethereum",
-    packages=find_packages(exclude=["tests", "tests.*"]),
+    packages=find_packages(exclude=["scripts", "scripts.*", "tests", "tests.*"]),
     package_data={"hexbytes": ["py.typed"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -68,5 +69,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/tests/core/test_hexbytes.py
+++ b/tests/core/test_hexbytes.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eth_utils import (
     decode_hex,
     remove_0x_prefix,
@@ -7,7 +9,6 @@ from hypothesis import (
     given,
     strategies as st,
 )
-import pytest
 
 from hexbytes import (
     HexBytes,

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{38,39,310,311,312}-core
-    py{38,39,310,311,312}-lint
-    py{38,39,310,311,312}-wheel
+    py{38,39,310,311,312,313}-core
+    py{38,39,310,311,312,313}-lint
+    py{38,39,310,311,312,313}-wheel
     windows-wheel
     docs
 
@@ -11,6 +11,9 @@ exclude=venv*,.tox,docs,build
 extend-ignore=E203
 max-line-length=88
 per-file-ignores=__init__.py:F401
+
+[blocklint]
+max_issue_threshold=1
 
 [testenv]
 usedevelop=True
@@ -25,19 +28,20 @@ basepython=
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 extras=
     test
     docs
 allowlist_externals=make,pre-commit
 
-[testenv:py{38,39,310,311,312}-lint]
+[testenv:py{38,39,310,311,312,313}-lint]
 deps=pre-commit
 extras=dev
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{38,39,310,311,312}-wheel]
+[testenv:py{38,39,310,311,312,313}-wheel]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?

py313 is in!

### How was it fixed?

Merge template, adding py313 support, dropping `bumpversion` for `bump-my-version`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/99ccd99b-6a02-4866-889a-80b98898bb4f)
