### PR TITLE
feat: bypass input validation for faster unpickling

### DIFF
--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -3,7 +3,6 @@ from typing import (
     Callable,
     Tuple,
     Type,
-    TypeVar,
     Union,
     cast,
     overload,
@@ -17,8 +16,6 @@ if TYPE_CHECKING:
     from typing import (
         SupportsIndex,
     )
-
-_THexBytes = TypeVar("_THexBytes", bound="HexBytes")
 
 BytesLike = Union[bool, bytearray, bytes, int, str, memoryview]
 
@@ -65,15 +62,11 @@ class HexBytes(bytes):
         return "0x" + self.hex()
 
     def __reduce__(
-        self
-    ) -> Tuple[
-        Callable[[Type[_THexBytes], bytes], _THexBytes], 
-        Tuple[Type[_THexBytes], bytes],
-    ]:
+        self,
+    ) -> Tuple[Callable[..., bytes], Tuple[Type["HexBytes"], bytes]]:
         """
-        An optimized `__reduce__` that bypasses the input validation in `HexBytes.__new__`
-        since an existing HexBytes instance has already been validated when created.
-
-        This enables much faster unpickling of HexBytes objects.
+        An optimized ``__reduce__`` that bypasses the input validation in
+        ``HexBytes.__new__`` since an existing HexBytes instance has already been
+        validated when created.
         """
         return bytes.__new__, (type(self), bytes(self))

--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -1,6 +1,9 @@
 from typing import (
     TYPE_CHECKING,
+    Callable,
+    Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
     overload,
@@ -14,6 +17,8 @@ if TYPE_CHECKING:
     from typing import (
         SupportsIndex,
     )
+
+_THexBytes = TypeVar("_THexBytes", bound="HexBytes")
 
 BytesLike = Union[bool, bytearray, bytes, int, str, memoryview]
 
@@ -58,3 +63,17 @@ class HexBytes(bytes):
         Convert the bytes to a 0x-prefixed hex string
         """
         return "0x" + self.hex()
+
+    def __reduce__(
+        self
+    ) -> Tuple[
+        Callable[[Type[_THexBytes], bytes], _THexBytes], 
+        Tuple[Type[_THexBytes], bytes],
+    ]:
+        """
+        An optimized `__reduce__` that bypasses the input validation in `HexBytes.__new__`
+        since an existing HexBytes instance has already been validated when created.
+
+        This enables much faster unpickling of HexBytes objects.
+        """
+        return bytes.__new__, (type(self), bytes(self))

--- a/newsfragments/52.performance.rst
+++ b/newsfragments/52.performance.rst
@@ -1,0 +1,1 @@
+Add an optimized ``__reduce__`` method to the ``HexBytes`` class that avoids validation when pickling / unpickling since the instance is already validated on creation.

--- a/tests/core/test_hexbytes.py
+++ b/tests/core/test_hexbytes.py
@@ -1,4 +1,5 @@
 import pytest
+import pickle
 
 from eth_utils import (
     decode_hex,
@@ -125,3 +126,22 @@ def test_slice_stepped(primitive, start, stop, step):
         step = None
     expected = HexBytes(primitive[start:stop:step])
     assert hexbytes[start:stop:step] == expected
+
+
+def test_reduce_consistency():
+    obj = HexBytes(b"0x1234")
+
+    reduce_fn, reduce_args, *maybe_state = obj.__reduce__()
+
+    # recreate manually using reduce_fn
+    recreated = reduce_fn(*reduce_args)
+    if maybe_state:
+        recreated.__setstate__(maybe_state[0])
+
+    # check recreated instance equals original
+    assert recreated == obj  # or compare fields manually
+
+    dumped = pickle.dumps(obj)
+    loaded = pickle.loads(dumped)
+
+    assert loaded == obj


### PR DESCRIPTION
We can do this because 

### What was wrong?
Unpickling of HexBytes objects is inefficient because it involves the input validation logic in HexBytes.__new__, which is not necessary because an existing HexBytes instance has already had its input validated when it was first created. This makes for a needlessly slow startup time for many of my, and presumably others', projects. In my case, this can make it quite time consuming to iterate on certain code changes and I think the dev UX can be much improved. 


### How was it fixed?
The addition of a specialized __reduce__ method that bypasses the extra steps in HexBytes.__new__ but produces the same final result

Note: This is *not* a breaking change, existing pickled HexBytes instances will continue to unpickle just fine.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes  (no documentation necessary for this change)
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)
- [x] Add tests
- ~~[ ] Add benchmark (necessary?)~~

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/f90f93c4-c491-431d-8f07-c290cf39ed43)
