### PR TITLE
remove hypothesis upper pin

### DIFF
--- a/newsfragments/53.misc.rst
+++ b/newsfragments/53.misc.rst
@@ -1,0 +1,1 @@
+For developers: Removes ``hypothesis`` upper pin, silencing some deprecation warnings coming from the earlier upper pin by allowing later hypothesis versions to be used.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
     ],
     "test": [
         "eth_utils>=2.0.0",
-        "hypothesis>=3.44.24,<=6.31.6",
+        "hypothesis>=3.44.24",
         "pytest>=7.0.0",
         "pytest-xdist>=2.4.0",
     ],


### PR DESCRIPTION
### What was wrong?

- Closes #51, allowing latest versions of hypothesis which internally corrected the deprecation warnings from #51.

Curious why this pin was there in the first place. This seems to work fine and it's only for the `test` dependency + aligns with our philosophy of no upper pins. Also is not present in some of our other libs.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)

#### Cute Animal Picture

`o_0`
