### PR TITLE
performance: remove redundant cast

### DIFF
--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -4,7 +4,6 @@ from collections.abc import (
 from typing import (
     TYPE_CHECKING,
     Union,
-    cast,
     overload,
 )
 
@@ -33,7 +32,7 @@ class HexBytes(bytes):
 
     def __new__(cls: type[bytes], val: BytesLike) -> "HexBytes":
         bytesval = to_bytes(val)
-        return cast(HexBytes, super().__new__(cls, bytesval))  # type: ignore  # https://github.com/python/typeshed/issues/2630  # noqa: E501
+        return super().__new__(cls, bytesval)
 
     @overload
     def __getitem__(self, key: "SupportsIndex") -> int:  # noqa: F811

--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -30,7 +30,7 @@ class HexBytes(bytes):
         3. ``to_0x_hex`` returns a 0x-prefixed hex string
     """
 
-    def __new__(cls: type[bytes], val: BytesLike) -> "HexBytes":
+    def __new__(cls, val: BytesLike) -> "HexBytes":
         bytesval = to_bytes(val)
         return super().__new__(cls, bytesval)
 

--- a/newsfragments/55.performance.rst
+++ b/newsfragments/55.performance.rst
@@ -1,0 +1,1 @@
+remove redundant cast in __new__


### PR DESCRIPTION
https://github.com/python/typeshed/issues/2630 has been resolved, so the `cast` is now redundant and can be removed

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes - N/A
- [x] Add entry to the [release notes](https://github.com/ethereum/hexbytes/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpapercave.com/wp/9vp5HZH.jpg)
