### PR TITLE
perf: format HexBytes repr without intermediate string

### DIFF
--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -51,7 +51,7 @@ class HexBytes(bytes):
             return result
 
     def __repr__(self) -> str:
-        return f"HexBytes({'0x' + self.hex()!r})"
+        return f"HexBytes('0x{self.hex()}')"
 
     def to_0x_hex(self) -> str:
         """


### PR DESCRIPTION
### What I did

Optimized `HexBytes.__repr__()` by formatting the final repr string directly.

fixes: N/A

### How I did it

Replaced the intermediate `"0x" + self.hex()` string construction with a single f-string that preserves the exact existing repr output.

Local CPython 3.12.3 `timeit` result, median of 7 repeats:
- 1024-byte value: 1658.8 ns -> 542.7 ns, 3.06x faster

### How to verify it

Run pytest, ruff check, ruff format check, and mypy via `uv`. Existing repr tests verify the output remains unchanged.

### Checklist

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete