### PR TITLE
perf: construct HexBytes from bytes without helper dispatch

### DIFF
--- a/hexbytes/main.py
+++ b/hexbytes/main.py
@@ -30,6 +30,8 @@ class HexBytes(bytes):
     """
 
     def __new__(cls, val: BytesLike) -> "HexBytes":
+        if isinstance(val, bytes):
+            return super().__new__(cls, val)
         bytesval = to_bytes(val)
         return super().__new__(cls, bytesval)
 

--- a/tests/core/test_hexbytes.py
+++ b/tests/core/test_hexbytes.py
@@ -36,6 +36,20 @@ def test_bytes_inputs(primitive):
     assert_equal(wrapped, primitive)
 
 
+def test_hexbytes_input_creates_new_instance():
+    wrapped = HexBytes(b"abc")
+    assert HexBytes(wrapped) is not wrapped
+
+
+def test_bytes_input_preserves_subclass():
+    class CustomHexBytes(HexBytes):
+        pass
+
+    wrapped = CustomHexBytes(b"abc")
+    assert type(wrapped) is CustomHexBytes
+    assert type(CustomHexBytes(HexBytes(b"abc"))) is CustomHexBytes
+
+
 @given(st.binary())
 def test_bytearray_inputs(primitive):
     byte_array_input = bytearray(primitive)


### PR DESCRIPTION
### What I did

Optimized `HexBytes` construction from existing bytes inputs by skipping helper dispatch.

fixes: N/A

### How I did it

Added an `isinstance(val, bytes)` fast path in `HexBytes.__new__()` that constructs directly with `super().__new__()`. This intentionally does not reuse the input object, preserving current identity behavior.

Local CPython 3.12.3 `timeit` results, median of 7 repeats:
- small `bytes`: 132.1 ns -> 121.8 ns, 1.08x faster
- 1024-byte `bytes`: 150.1 ns -> 138.5 ns, 1.08x faster
- existing `HexBytes`: 141.5 ns -> 131.4 ns, 1.08x faster

### How to verify it

Run pytest, ruff check, ruff format check, and mypy via `uv`. The added tests verify `HexBytes(existing_hexbytes)` still creates a new object and subclass construction still returns the subclass.

### Checklist

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete